### PR TITLE
feat: support to use import.meta.url on commonjs

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -13,4 +13,4 @@ jobs:
     uses: node-modules/github-actions/.github/workflows/node-test.yml@master
     with:
       os: 'ubuntu-latest'
-      version: '16, 18, 20'
+      version: '16, 18, 20, 22'

--- a/.github/workflows/pkg.pr.new.yml
+++ b/.github/workflows/pkg.pr.new.yml
@@ -1,0 +1,23 @@
+name: Publish Any Commit
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - run: corepack enable
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build
+        run: npm run prepublishOnly --if-present
+
+      - run: npx pkg-pr-new publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,5 +11,3 @@ jobs:
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       GIT_TOKEN: ${{ secrets.GIT_TOKEN }}
-    with:
-      checkTest: false

--- a/README.md
+++ b/README.md
@@ -5,3 +5,26 @@ Auto set package.json after [tshy](https://github.com/isaacs/tshy) run
 ## keep `types`
 
 Set `package.types` to `package.exports['.'].require.types`
+
+## Auto fix `import.meta.url` SyntaxError on CJS
+
+```bash
+SyntaxError: Cannot use 'import.meta' outside a module
+```
+
+e.g.: Get the file's dirname
+
+```ts
+// src/index.ts
+
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+export function getDirname() {
+  if (typeof __dirname !== 'undefined') {
+    return __dirname;
+  }
+  // @ts-ignore
+  return path.dirname(fileURLToPath(import.meta.url));
+}
+```

--- a/package.json
+++ b/package.json
@@ -43,13 +43,18 @@
     "./package.json": "./package.json",
     ".": {
       "import": {
+        "source": "./src/index.ts",
         "types": "./dist/esm/index.d.ts",
         "default": "./dist/esm/index.js"
       },
       "require": {
+        "source": "./src/index.ts",
         "types": "./dist/commonjs/index.d.ts",
         "default": "./dist/commonjs/index.js"
       }
     }
-  }
+  },
+  "main": "./dist/commonjs/index.js",
+  "types": "./dist/commonjs/index.d.ts",
+  "module": "./dist/esm/index.js"
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,31 @@
 #!/usr/bin/env node
 
-import { writeFileSync, readFileSync } from 'node:fs'
+import { writeFileSync, readFileSync, readdirSync, statSync } from 'node:fs'
+import path from 'node:path'
 
-const pkg = JSON.parse(readFileSync('package.json', 'utf-8'));
+const cwd = process.cwd();
+
+const pkg = JSON.parse(readFileSync(path.join(cwd, 'package.json'), 'utf-8'));
 // make sure commonjs *.d.ts can import types
 pkg.types = pkg.exports['.'].require.types;
 
 writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n')
+
+// Replace all `import.meta.url` into 'import.meta.url' string placeholder on commonjs.
+function replaceImportMetaUrl(baseDir: string) {
+  const names = readdirSync(baseDir);
+  for (const name of names) {
+    const filepath = path.join(baseDir, name);
+    const stat = statSync(filepath);
+    if (stat.isDirectory()) {
+      replaceImportMetaUrl(filepath);
+      continue;
+    }
+    if (!filepath.endsWith('.js')) {
+      continue;
+    }
+    writeFileSync(filepath, readFileSync(filepath, 'utf-8').replaceAll('import.meta.url', '"import_meta_url_placeholder_by_tshy_after"'));
+    console.log('Auto fix "import.meta.url" on %s', filepath);
+  }
+}
+replaceImportMetaUrl(path.join(cwd, 'dist/commonjs'));

--- a/test/fixtures/demo/src/index.ts
+++ b/test/fixtures/demo/src/index.ts
@@ -1,0 +1,10 @@
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+export function getDirname() {
+  if (typeof __dirname !== 'undefined') {
+    return __dirname;
+  }
+  // @ts-ignore
+  return path.dirname(fileURLToPath(import.meta.url));
+}

--- a/test/fixtures/demo/src/tsconfig.json
+++ b/test/fixtures/demo/src/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "inlineSources": true,
+    "jsx": "react",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "noUncheckedIndexedAccess": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": false,
+    "sourceMap": true,
+    "strict": true,
+    "target": "es2022"
+  }
+}

--- a/test/fixtures/demo/tsconfig.json
+++ b/test/fixtures/demo/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "inlineSources": true,
+    "jsx": "react",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "noUncheckedIndexedAccess": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "strict": true,
+    "target": "es2022"
+  }
+}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -20,7 +20,18 @@ describe('test/index.test.ts', () => {
   });
 
   it('should work', async () => {
+    await coffee.spawn('tshy', { cwd })
+      .debug()
+      .expect('code', 0)
+      .end();
     await coffee.fork(bin, { cwd })
+      .debug()
+      .expect('code', 0)
+      .end();
+    await coffee.spawn('node', [
+      '--require', './dist/commonjs/index.js',
+      '-p', '123123',
+    ], { cwd })
       .debug()
       .expect('code', 0)
       .end();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new GitHub Actions workflow to publish on any commit or pull request.
  - Added a function to handle `import.meta.url` in CommonJS modules.

- **Improvements**
  - Updated Node.js versions in workflows to include v22.
  - Enhanced `package.json` with updated paths for imports, exports, and types.
  - Improved file system operations and path handling within the project.
  - Updated TypeScript configurations for better code consistency and module handling.

- **Bug Fixes**
  - Addressed a `SyntaxError` related to `import.meta.url` in CommonJS modules.

- **Documentation**
  - Updated README with new instructions for auto-setting `package.json`.

- **Tests**
  - Expanded test scenarios with additional asynchronous calls and configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->