### PR TITLE
feat: auto fix import.meta.resolve SyntaxError on CJS

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -13,3 +13,5 @@ jobs:
     with:
       os: 'ubuntu-latest, windows-latest'
       version: '16, 18, 20, 22, 23'
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,5 @@ dist
 .pnp.*
 
 .tshy
+package-lock.json
+.package-lock.json

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Node.js CI](https://github.com/node-modules/tshy-after/actions/workflows/nodejs.yml/badge.svg)](https://github.com/node-modules/tshy-after/actions/workflows/nodejs.yml)
 [![npm download][download-image]][download-url]
 [![Node.js Version](https://img.shields.io/node/v/tshy-after.svg?style=flat)](https://nodejs.org/en/download/)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](https://makeapullrequest.com)
 
 [npm-image]: https://img.shields.io/npm/v/tshy-after.svg?style=flat-square
 [npm-url]: https://npmjs.org/package/tshy-after
@@ -16,7 +17,7 @@ Auto set package.json after [tshy](https://github.com/isaacs/tshy) run
 
 Set `package.types` to `package.exports['.'].require.types`
 
-## Auto fix `import.meta.url` SyntaxError on CJS
+## Auto fix `import.meta.url` and `import.meta.resolve` SyntaxError on CJS
 
 ```bash
 SyntaxError: Cannot use 'import.meta' outside a module

--- a/test/fixtures/demo/src/index.ts
+++ b/test/fixtures/demo/src/index.ts
@@ -8,3 +8,11 @@ export function getDirname() {
   // @ts-ignore
   return path.dirname(fileURLToPath(import.meta.url));
 }
+
+export function resolve(filename: string) {
+  if (typeof require === 'function') {
+    return require.resolve(filename);
+  }
+  // @ts-ignore
+  return import.meta.resolve(filename);
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new badge in the README to indicate contributions are welcome.
	- Introduced a `resolve` function for enhanced filename resolution in the module.

- **Bug Fixes**
	- Updated handling of `import.meta.url` and `import.meta.resolve` for improved CommonJS compatibility.

- **Chores**
	- Added `package-lock.json` and `.package-lock.json` to the `.gitignore` file.
	- Enhanced GitHub Actions workflow with a new `CODECOV_TOKEN` secret.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->