### PR TITLE
fix: make sure copy file parent dir exits

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { writeFileSync, readFileSync, readdirSync, statSync, copyFileSync } from 'node:fs'
+import { writeFileSync, readFileSync, readdirSync, statSync, copyFileSync, mkdirSync } from 'node:fs'
 import path from 'node:path'
 
 const cwd = process.cwd() + path.sep;
@@ -78,9 +78,11 @@ function copyFiles(baseDir: string) {
       continue;
     }
     let targetFilepath = filepath.replace(sourceDir, commonjsDir);
+    mkdirSync(path.dirname(targetFilepath), { recursive: true });
     copyFileSync(filepath, targetFilepath);
     console.log('Copy %s to %s', filepath.replace(cwd, ''), targetFilepath.replace(cwd, ''));
     targetFilepath = filepath.replace(sourceDir, esmDir);
+    mkdirSync(path.dirname(targetFilepath), { recursive: true });
     copyFileSync(filepath, targetFilepath);
     console.log('Copy %s to %s', filepath.replace(cwd, ''), targetFilepath.replace(cwd, ''));
   }

--- a/test/fixtures/demo/src/templates/bar.html
+++ b/test/fixtures/demo/src/templates/bar.html
@@ -1,0 +1,1 @@
+hello world

--- a/test/fixtures/demo/src/templates/foo.html
+++ b/test/fixtures/demo/src/templates/foo.html
@@ -1,0 +1,1 @@
+hello world

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -52,6 +52,15 @@ describe('test/index.test.ts', () => {
     jsonFile = path.join(cwd, 'dist/esm/bar.json');
     assert.equal(fs.statSync(jsonFile).isFile(), true);
 
+    let htmlFile = path.join(cwd, 'dist/commonjs/templates/foo.html');
+    assert.equal(fs.statSync(htmlFile).isFile(), true);
+    htmlFile = path.join(cwd, 'dist/esm/templates/foo.html');
+    assert.equal(fs.statSync(htmlFile).isFile(), true);
+    htmlFile = path.join(cwd, 'dist/commonjs/templates/bar.html');
+    assert.equal(fs.statSync(htmlFile).isFile(), true);
+    htmlFile = path.join(cwd, 'dist/esm/templates/bar.html');
+    assert.equal(fs.statSync(htmlFile).isFile(), true);
+
     // should dist/package.json exists, include name and version
     const distPackageFile = path.join(cwd, 'dist/package.json');
     const distPkg = JSON.parse(fs.readFileSync(distPackageFile, 'utf-8'));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved file processing now automatically creates needed directories before transferring files, reducing potential errors.
	- Updated HTML templates with additional content for a cleaner output.
- **Tests**
	- Enhanced test coverage to verify that the updated HTML files are correctly deployed in the output paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->